### PR TITLE
Running black, isort, flake8 and pytest on CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+exclude = .git,__pycache__,.venv
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,11 +1,12 @@
 name: default-workflow
 
 on: 
-  push:
   pull_request:
 
 jobs:
   build:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest   
     strategy:
       matrix:
@@ -20,7 +21,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
+        pip install -e .
     - name: Running pre-commit
       uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files
+    - name: Run tests
+      continue-on-error: true
+      run: pytest --junitxml=pytest.xml
+    - name: Pytest coverage comment
+      uses: MishaKav/pytest-coverage-comment@main
+      if: github.event_name == 'pull_request'
+      with:
+        pytest-xml-coverage-path: ./covreport.xml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,8 @@
-name: black-on-push
+name: default-workflow
 
-on: [push]
+on: 
+  push:
+  pull_request:
 
 jobs:
   build:
@@ -17,7 +19,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black    
-    - name: Formatting the code with black
-      run: |
-        black --check --diff .
+        pip install -r requirements.txt -r requirements-dev.txt
+    - name: Running pre-commit
+      uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --all-files

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         extra_args: --all-files
     - name: Run tests
+      continue-on-error: true
       run: pytest --junitxml=pytest.xml
     # - name: Pytest coverage comment
     #   uses: MishaKav/pytest-coverage-comment@main

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: default-workflow
+name: pull_request
 
 on: 
   pull_request:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,7 +1,8 @@
-name: pull_request
+name: push
 
 on: 
   pull_request:
+  push:
 
 jobs:
   build:
@@ -27,10 +28,9 @@ jobs:
       with:
         extra_args: --all-files
     - name: Run tests
-      continue-on-error: true
       run: pytest --junitxml=pytest.xml
-    - name: Pytest coverage comment
-      uses: MishaKav/pytest-coverage-comment@main
-      if: github.event_name == 'pull_request'
-      with:
-        pytest-xml-coverage-path: ./covreport.xml
+    # - name: Pytest coverage comment
+    #   uses: MishaKav/pytest-coverage-comment@main
+    #   if: github.event_name == 'pull_request'
+    #   with:
+    #     pytest-xml-coverage-path: ./covreport.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ forge.yaml
 
 *.py[cod]
 
+covreport.xml
+
 # C extensions
 *.so
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:  
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml

--- a/app/api.py
+++ b/app/api.py
@@ -1,8 +1,8 @@
-from fastapi import FastAPI, Request
-from starlette.responses import RedirectResponse, JSONResponse
 from typing import Union
 
 import httpx
+from fastapi import FastAPI, Request
+from starlette.responses import JSONResponse, RedirectResponse
 
 app = FastAPI(
     title="KoboldAI Interceptor",

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
-from pydantic import BaseModel
 
+from pydantic import BaseModel
 
 ENT_PROP_MAP = {
     "CARDINAL": "cardinals",

--- a/app/spacy_extractor.py
+++ b/app/spacy_extractor.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, Iterable
+
 from spacy.language import Language
 
 

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -1,4 +1,5 @@
 from starlette.testclient import TestClient
+
 from app.api import app
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import uvicorn
-from app.api import app
 
+from app.api import app
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=9000, log_level="info")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+target-version = ['py310']
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,9 @@ target-version = ['py310']
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "app/tests",
+]
+addopts = "--cov=app --cov-report xml:covreport.xml"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+black
+isort
+flake8
+pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@ black
 isort
 flake8
 pre-commit
+pytest
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import find_packages, setup
+
+setup(name="koboldai-interceptor", packages=find_packages())


### PR DESCRIPTION
This PR adds the following features:
* requirements-dev.txt with optional dev dependencies
* pre-commit configuration including black, isort and flake8
* pre-commit is run on merge request and push
* running pytest using github actions

Currently, there is no coverage report, external service (like codecov) is imo preferred.

Right now included tests are not passing so the pipeline falls.